### PR TITLE
Developers dark mode

### DIFF
--- a/app/developers/components/dev-card.tsx
+++ b/app/developers/components/dev-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import DeveloperAvatar from "./dev-avatar";
+import { Github } from "lucide-react";
 
 export default function DeveloperCard() {
     return (
@@ -15,15 +16,20 @@ export default function DeveloperCard() {
                     </div>
                 </CardHeader>
                 <CardContent>
-                    Github:
+                    
+                <div className="flex items-center gap-2">
+                        <div className="flex items-center">
+                            <Github className="w-5 h-5" />
+                            <span className="ml-1">Github:</span>
+                        </div>
+                        <a
+                            className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            href="https://github.com/ryotakc"
+                        >
+                            Ryota
+                        </a>
+                </div>
 
-
-                    <a
-                    className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    href="https://github.com/ryotakc"
-                    >
-                     Ryota
-                    </a>
                 </CardContent>
             </Card>
 
@@ -38,14 +44,20 @@ export default function DeveloperCard() {
                     </div>
                 </CardHeader>
                 <CardContent>
-                    Github:
 
-                    <a
-                    className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    href="https://github.com/eito8210"
-                    >
-                    Eito
-                    </a>
+                <div className="flex items-center gap-2">
+                        <div className="flex items-center">
+                            <Github className="w-5 h-5" />
+                            <span className="ml-1">Github:</span>
+                        </div>
+                        <a
+                            className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            href="https://github.com/eito8210"
+                        >
+                        Eito 
+                        </a>
+
+                </div>
 
                 </CardContent>
             </Card>
@@ -61,13 +73,18 @@ export default function DeveloperCard() {
                     </div>
                 </CardHeader>
                 <CardContent>
-                    Github:
-                    <a
-                    className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    href="https://github.com/TulikaVarma?tab=repositories"
-                    >
-                         Tulika 
-                    </a>
+                <div className="flex items-center gap-2">
+                        <div className="flex items-center">
+                            <Github className="w-5 h-5" />
+                            <span className="ml-1">Github:</span>
+                        </div>
+                        <a
+                            className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            href="https://github.com/TulikaVarma"
+                        >
+                        Tulika 
+                        </a>
+                </div>
                 </CardContent>
             </Card>
 
@@ -82,13 +99,18 @@ export default function DeveloperCard() {
                     </div>
                 </CardHeader>
                 <CardContent>
-                    Github: 
-                    <a
-                    className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    href=""
-                    >
-                         Ansh
-                    </a>
+                <div className="flex items-center gap-2">
+                        <div className="flex items-center">
+                            <Github className="w-5 h-5" />
+                            <span className="ml-1">Github:</span>
+                        </div>
+                        <a
+                            className="text-black dark:text-white underline underline-offset-1 decoration-black dark:decoration-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            href="https://github.com/zorojuro12"
+                        >
+                            Ansh
+                        </a>
+                </div>
                 </CardContent>
             </Card>
         </div>


### PR DESCRIPTION
This pull request includes changes to the `DeveloperCard` component to improve the display of GitHub profiles for developers. The changes enhance the visual presentation and ensure consistency across different themes.

Improvements to `DeveloperCard` component:

* [`app/developers/components/dev-card.tsx`](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542R3): Imported `Github` from `lucide-react` to use the GitHub icon in the component.
* [`app/developers/components/dev-card.tsx`](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542L18-R32): Updated the GitHub profile link section to include the GitHub icon and improved the styling for better visual presentation. Each developer's GitHub link now includes a consistent icon and text styling, with theme-aware colors and hover effects. [[1]](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542L18-R32) [[2]](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542L38-R61) [[3]](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542L58-R87) [[4]](diffhunk://#diff-3c8ef5eecd1afaf8006ae941a6f006a87ce663e0bc630fc67fb03ac4bdf46542L78-R113)